### PR TITLE
Master

### DIFF
--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -139,9 +139,15 @@ class WeatherLevelChecker(Thread):
 
                     water_adjustment = max(safe_float(options['wl_min']), min(safe_float(options['wl_max']), water_adjustment))
 
+                    #Do not run if the current temperature is below 4 Celsius
+                    if today['temp_c'] <= 4:
+                        water_adjustment = 0
+
+                    self.add_status('Current temp in C    : %.1f' % today['temp_c'])
+                    self.add_status('________________________________')
                     self.add_status('Water needed (%d days): %.1fmm' % (len(info), water_needed))
                     self.add_status('Total rainfall       : %.1fmm' % total_info['rain_mm'])
-                    self.add_status('_______________________________-')
+                    self.add_status('________________________________')
                     self.add_status('Irrigation needed    : %.1fmm' % water_left)
                     self.add_status('Weather Adjustment   : %.1f%%' % water_adjustment)
 


### PR DESCRIPTION
Don’t run the sprinklers if the current temperature is below 4 degrees
Celsius.

I caught my sprinklers running this morning when it was at freezing 0C. We have a large temperature swing throughout the day. I want the sprinklers running if it’s warm, but not if it’s too close to freezing.

I added a check for the current temperature each time the weather is retrieved. If it’s <= 4C I set water_adjustment = 0 so that the sprinklers won’t run.